### PR TITLE
prevent empty data payload from being send to host

### DIFF
--- a/.github/workflows/updateChangelog.yml
+++ b/.github/workflows/updateChangelog.yml
@@ -16,7 +16,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8 #install the python needed
+          python-version: 3.8 # install the python needed
       - name: Install dependencies
         run: |
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: itential
 name: core
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: 1.0.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: itential
 name: core
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.1
+version: 1.0.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
 ---
 # Collections must specify a minimum required ansible version to upload
 # to galaxy
-requires_ansible: ">=2.12.0"
+requires_ansible: ">=2.15.0"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
 ---
 # Collections must specify a minimum required ansible version to upload
 # to galaxy
-requires_ansible: ">=2.17.0"
+requires_ansible: ">=2.12.0"

--- a/plugins/module_utils/display.py
+++ b/plugins/module_utils/display.py
@@ -3,10 +3,27 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import os
+
 from ansible.utils.display import Display
 
 
 display = Display()
+
+
+def set_verbosity(lvl) -> None:
+    """Overrides the verbosity level
+
+    Args:
+        lvl (int): The verbosity level to set.  Value values are in the
+            range of 1 to 5
+
+    Returns:
+        None
+    """
+    if lvl is not None:
+        if 0 <= lvl <= 6:
+            display.verbosity = lvl
 
 
 def tostring(msg) -> None:

--- a/plugins/module_utils/hosts.py
+++ b/plugins/module_utils/hosts.py
@@ -28,6 +28,13 @@ def new(spec, hostvars) -> typing.Any:
     Returns:
         An immutable instance that represents the host
     """
+    display.trace("hosts.new")
+
+    verbosity = hostvars.get("itential_verbosity")
+    if verbosity is not None:
+        if hostvars.get("ansible_verbosity") < verbosity:
+            display.set_verbosity(verbosity)
+
     options = spec.get("options")
 
     values = dict()

--- a/plugins/module_utils/http.py
+++ b/plugins/module_utils/http.py
@@ -51,6 +51,8 @@ def send_request(method, url, headers=None, data=None, params=None, auth=None, t
     Returns
         A `Response` object that contains the response from the API call
     """
+    display.trace("http.send_request")
+
     if disable_warnings is True:
         urllib3.disable_warnings()
 
@@ -75,13 +77,17 @@ def send_request(method, url, headers=None, data=None, params=None, auth=None, t
     if isinstance(kwargs.get("data"), (dict, list)):
         kwargs["data"] = json.dumps(data)
 
-    display.vvvvv(f"Request: {kwargs}")
+    display.vvvvv(f"Request object: {kwargs}")
 
     try:
         if session is not None:
             resp = session.request(**kwargs)
         else:
             resp = requests.request(**kwargs)
+
+        display.vvv(f"HTTP response is {resp.status_code} {resp.reason}")
+        display.vvvvv(f"Start of response body\n{resp.text}\nEnd of response body")
+        display.vvvvv(f"Call completed in {resp.elapsed}")
 
     except requests.exceptions.ConnectionError as exc:
         display.vvvvv(traceback.format_exc())
@@ -116,7 +122,7 @@ def make_url(host, path, port=0, use_tls=True) -> str:
     Returns:
         A string that represents the full URL
     """
-    display.trace("http.make_url()", host=host)
+    display.trace("http.make_url")
 
     if port == 0:
         port = 443 if use_tls is True else 80
@@ -146,6 +152,7 @@ def basic_auth(username, password) -> HTTPBasicAuth:
     Returns:
         A `requests.HTTPBasicAuth` object
     """
+    display.trace("http.basic_auth")
     return HTTPBasicAuth(username, password)
 
 
@@ -231,6 +238,7 @@ class Session(object):
         session (requests.Session): The requests library session.
     """
     def __init__(self, name):
+        display.trace("http.Session.init")
         self.name = name
         self.session = requests.Session()
 
@@ -244,7 +252,7 @@ class Session(object):
         Returns:
             A `Response` object
         """
-        display.trace("Session.send()", host=self.name)
+        display.trace("http.Session.send")
 
         url = make_url(
             request.host,
@@ -252,8 +260,6 @@ class Session(object):
             request.port,
             request.use_tls,
         )
-
-        display.vvv(f"{request.method} {url}", host=self.name)
 
         resp = send_request(
             method=request.method,
@@ -264,9 +270,6 @@ class Session(object):
             disable_warnings=request.disable_warnings,
             session=self.session
         )
-
-        display.vvv(f"RESPONSE status_code={resp.status_code}", host=self.name)
-        display.vvv(f"Elapsed time {resp.elapsed}", host=self.name)
 
         return Response(
             status_code=resp.status_code,

--- a/plugins/module_utils/http.py
+++ b/plugins/module_utils/http.py
@@ -60,7 +60,6 @@ def send_request(method, url, headers=None, data=None, params=None, auth=None, t
         "method": method,
         "url": url,
         "headers": headers,
-        "data": data,
         "params": params,
         "verify": verify,
     }
@@ -74,7 +73,7 @@ def send_request(method, url, headers=None, data=None, params=None, auth=None, t
     if certificate_file is not None and private_key_file is not None:
         kwargs["cert"] = (certificate_file, private_key_file)
 
-    if isinstance(kwargs.get("data"), (dict, list)):
+    if isinstance(kwargs.get("data"), (dict, list)) and kwargs.get("data"):
         kwargs["data"] = json.dumps(data)
 
     display.vvvvv(f"Request object: {kwargs}")

--- a/plugins/modules/include_vars.py
+++ b/plugins/modules/include_vars.py
@@ -36,8 +36,8 @@ options:
 
 
 EXAMPLES = """
-  - name: Include all files from config
-    itential.core.include_vars:
-      name: config
-      path: path/to/files
+- name: Include all files from config
+  itential.core.include_vars:
+    name: config
+    path: path/to/files
 """


### PR DESCRIPTION
This commit addresses an issue where an empty data payload would be send
to the host as an empty array or empty object.  This change will now
check if the data is empty and not attempting to send it to the host if
it is.