### PR TITLE
remove data encoding to json

### DIFF
--- a/plugins/module_utils/http.py
+++ b/plugins/module_utils/http.py
@@ -73,8 +73,10 @@ def send_request(method, url, headers=None, data=None, params=None, auth=None, t
     if certificate_file is not None and private_key_file is not None:
         kwargs["cert"] = (certificate_file, private_key_file)
 
-    if isinstance(kwargs.get("data"), (dict, list)) and kwargs.get("data"):
-        kwargs["data"] = json.dumps(data)
+    if data is not None:
+        if not isinstance(data, bytes):
+            raise AnsibleError(f"invalid type for data, expected bytes, got {type(data)}")
+        kwargs["data"] = data
 
     display.vvvvv(f"Request object: {kwargs}")
 


### PR DESCRIPTION
This commit removes the logic to encode the payload before sending the request.  This library should not attempt to infer the data type and simply add the data to the request exactly as it was passed to the function.  It is the responsibility of the upstream function to call the function with the appropriately encoded data.